### PR TITLE
Enhance Docker entrypoint and build scripts for micro-ROS

### DIFF
--- a/scripts/build_micro_ros.sh
+++ b/scripts/build_micro_ros.sh
@@ -10,8 +10,9 @@ git config --global --add safe.directory $ROS_WS/src/uros/micro_ros_msgs
 echo -e "\033[1;32m--------------- [ micro-ROS Build Start ] ----------------\033[0m"
 sudo apt-get update
 rosdep update
+rosdep install --from-paths src --ignore-src -y
 
-source ./install/setup.bash
+source ./install/local_setup.bash
 
 echo -e "\033[1;32m--------------- [ micro-ROS Agent Creat ] ------------------\033[0m"
 ros2 run micro_ros_setup create_agent_ws.sh


### PR DESCRIPTION
This pull request includes several changes to the `docker/entrypoint.sh` and `scripts/build_micro_ros.sh` files to improve the build and execution process for the ROS workspace. The most important changes include switching the user to `ros`, modifying the build process to skip certain packages if already built, and updating the execution command.

### Improvements to user switching and build process:

* [`docker/entrypoint.sh`](diffhunk://#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7caR18-R23): Added a check to switch to the `ros` user if the current user ID does not match the expected user ID.
* [`docker/entrypoint.sh`](diffhunk://#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7caL34-L41): Modified the build process to skip building `micro_ros_msgs` if it is already built, and added messages to indicate the build status.
* [`docker/entrypoint.sh`](diffhunk://#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7caL57-R71): Changed the execution command to run as the current user instead of using `gosu`.

### Improvements to micro-ROS setup script:

* [`scripts/build_micro_ros.sh`](diffhunk://#diff-dd58d287b76960134a4a0a13924ef267500d4a3db8fc82773ed00c5d9f1f2920R13-R15): Added a command to install dependencies using `rosdep` and updated the source command to use `local_setup.bash` instead of `setup.bash`.